### PR TITLE
feat: add Railway deployment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,10 @@ Despliegue en Railway
 ---------------------
 
 1. Crea un proyecto en Railway y añade un servicio a partir de este repositorio.
-2. Configura variables de entorno en Railway:
-   - `RUN_MODE=rest` para servicio HTTP (FastAPI)
-   - `PORT` (Railway lo inyecta automáticamente)
+2. Configura las variables de entorno necesarias (Railway inyecta `PORT` automáticamente):
    - `DATABASE_URL` (conecta a Postgres de Railway)
    - `SECRET_KEY`, `ALGORITHM`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `ADMIN_MASTER_KEY`, `ADMIN_TOKEN_EXPIRE_DAYS`
-3. Establece el comando de inicio del servicio HTTP: `python -m uvicorn main:api_app --host 0.0.0.0 --port $PORT`
-4. Para el servidor OCPP WS, crea otro servicio clonando este repo y usa:
-   - `RUN_MODE=ws`
-   - `PORT` (Railway)
-   - Comando: `python main.py`
-
-Nota: Puedes ejecutar ambos servicios en un único dyno en local, pero en Railway es recomendable separarlos en dos servicios.
+3. Railway detectará el `Dockerfile` y construirá la imagen. El servicio se inicia con `python main.py`.
+4. La API REST y el WebSocket OCPP comparten el mismo puerto `$PORT` en un único servicio.
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Dependencias
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Código fuente
+COPY . .
+
+# Exponer puerto esperado por Railway
+ENV PORT=8000
+EXPOSE 8000
+
+# Arranque del servidor (REST + WebSocket)
+CMD ["python", "main.py"]
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+
+services:
+  app:
+    build: ..
+    command: ["python", "main.py"]
+    ports:
+      - "8000:8000"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -e
+
+# Ejecuta el servidor FastAPI que expone REST y WebSocket en un único servicio
+python main.py
+


### PR DESCRIPTION
## Summary
- document single-service Railway deployment
- add Dockerfile and compose for REST+WS server
- provide entrypoint script running `python main.py`

## Testing
- `pytest` *(fails: fixture 'url' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689df4924a94832985a0a069bd3bc2a2